### PR TITLE
Fix build error on 32-bit ARM

### DIFF
--- a/defreview/src/DefReview.cpp
+++ b/defreview/src/DefReview.cpp
@@ -2,7 +2,9 @@
 #define LIB_NAME "DefReview"
 #define MODULE_NAME "defreview"
 
+#ifndef DLIB_LOG_DOMAIN
 #define DLIB_LOG_DOMAIN LIB_NAME
+#endif
 #include <dmsdk/sdk.h>
 
 #if defined(DM_PLATFORM_IOS)

--- a/defreview/src/objc/DefReviewIOS.h
+++ b/defreview/src/objc/DefReviewIOS.h
@@ -3,6 +3,5 @@
 
 extern bool DefReview_isSupported();
 extern void DefReview_requestReview();
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
 
 #endif

--- a/defreview/src/objc/DefReviewIOS.mm
+++ b/defreview/src/objc/DefReviewIOS.mm
@@ -4,19 +4,21 @@
 #include "DefReviewIOS.h"
 #include <StoreKit/StoreKit.h>
 
-NSString *minVersion = @"10.3";
+static Class getClass_SKStoreReviewController() {
+    // Cache the class in a static var
+    static const Class SKStoreReviewController_ = NSClassFromString(@"SKStoreReviewController");
+    return SKStoreReviewController_;
+}
 
 bool DefReview_isSupported() {
-    BOOL status = NO;
-    if(SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(minVersion)){
-        status = YES;
-    }
-    return status == YES;
+    Class SKStoreReviewController_ = getClass_SKStoreReviewController();
+    return !!SKStoreReviewController_;
 }
 
 void DefReview_requestReview() {
-	if (DefReview_isSupported()) {
-       [SKStoreReviewController requestReview];
+    Class SKStoreReviewController_ = getClass_SKStoreReviewController();
+    if (SKStoreReviewController_) {
+        [SKStoreReviewController_ performSelector:@selector(requestReview)];
     }
 }
 #endif


### PR DESCRIPTION
32-bit ARM on iOS probably uses an older SDK version and the build fails with a linker error about `SKStoreReviewController`. Hence, feature detection should still be employed. Also, feature detection is generally a better practice than depending on a system version anyway.