### PR TITLE
Android Play Core Review library

### DIFF
--- a/review/manifests/android/build.gradle
+++ b/review/manifests/android/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-  implementation 'com.google.android.play:core:1.10.2'
+  implementation 'com.google.android.play:review:2.0.0'
 }

--- a/review/src/android/java/com/defold/review/Review.java
+++ b/review/src/android/java/com/defold/review/Review.java
@@ -6,8 +6,8 @@ import android.os.Build;
 import com.google.android.play.core.review.ReviewInfo;
 import com.google.android.play.core.review.ReviewManager;
 import com.google.android.play.core.review.ReviewManagerFactory;
-import com.google.android.play.core.tasks.Task;
-import com.google.android.play.core.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.OnCompleteListener;
 
 public class Review {
 


### PR DESCRIPTION
Google recently split up the Play Core libraries, and changed them to use the [Google Play Services' Task API](https://developers.google.com/android/reference/com/google/android/gms/tasks/Task).

Migration guide:
https://developer.android.com/guide/playcore#playcore-migration

This is pretty nice, and resulted in 109KB of savings in a release-mode AAB.  I still need to test this on real devices, but given the simple migration steps, I expect this will just work.